### PR TITLE
ci: add auto-release workflow to publish VSIX on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build & publish VSIX
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Package extension
+        run: npm run package
+
+      - name: Get VSIX filename
+        id: vsix
+        run: echo "file=$(ls *.vsix | head -n 1)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload VSIX to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.vsix.outputs.file }}
+          generate_release_notes: true


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automate the build and release process for the extension. 

Previously, there was no automated mechanism to attach compiled `.vsix` binaries to GitHub Releases, requiring manual uploads so users could easily download them.

### Changes Made
* Added `.github/workflows/release.yml`
* Configured the workflow to trigger automatically whenever a new version tag (e.g., `v3.2.1`) is pushed.
* The workflow checks out the code, installs dependencies, compiles the extension via `npm run package`, and automatically attaches the resulting `.vsix` file to the GitHub Release.
* Enabled automated generation of release notes for the tags.
