### PR TITLE
fix: filter unsupported models from quota view

### DIFF
--- a/src/managers/accountCardBuilder.ts
+++ b/src/managers/accountCardBuilder.ts
@@ -6,6 +6,7 @@
 import { AccountQuota, AccountCard, ModelCard, LocalQuotaData } from '../types';
 import { shortModelName, normalizeModelKey } from '../shared/helpers';
 import { parseUserTier, parsePlanStatus } from '../utils/lsTypes';
+import { MODEL_DISPLAY_NAMES } from '../constants';
 
 /**
  * Build a normKey → LS label lookup map from local protobuf data.
@@ -70,8 +71,9 @@ export function buildAccountCards(
     const localEmail = (status?.email || '').toLowerCase();
 
     if (status) {
+        const knownDisplayNames = new Set(Object.values(MODEL_DISPLAY_NAMES));
         const rawModels = (status.cascadeModelConfigData?.clientModelConfigs || [])
-            .filter((m: any) => m.quotaInfo)
+            .filter((m: any) => m.quotaInfo && knownDisplayNames.has(m.label || shortModelName(m.modelOrAlias?.model)))
             .sort((a: any, b: any) => (a.label || '').localeCompare(b.label || ''));
 
         const models: ModelCard[] = rawModels.map((m: any) => ({

--- a/src/services/quotaApi.ts
+++ b/src/services/quotaApi.ts
@@ -67,8 +67,7 @@ export class QuotaApiService {
     /**
      * Parse retrieveUserQuota buckets[] response.
      * Each bucket: { tokenType, modelId, remainingFraction, resetTime? }
-     * Shows ALL models — no filtering. Uses display name overrides when available,
-     * otherwise auto-humanizes the model slug.
+     * Filters models to only show those explicitly mapped in Antigravity.
      */
     private parseBuckets(buckets: any[]): QuotaModel[] {
         const models: QuotaModel[] = [];
@@ -78,6 +77,12 @@ export class QuotaApiService {
             if (!modelId) continue;
 
             const cleanId = modelId.split('/').pop()!;
+            
+            // Only include models that are explicitly mapped in Antigravity
+            if (!MODEL_DISPLAY_NAMES[cleanId] && !MODEL_DISPLAY_NAMES[modelId]) {
+                continue;
+            }
+
             const displayName = MODEL_DISPLAY_NAMES[cleanId]
                 || MODEL_DISPLAY_NAMES[modelId]
                 || QuotaApiService.humanizeModelId(cleanId);


### PR DESCRIPTION
## Description

This PR fixes an issue where the Accounts tab displays a bloated list of internal, deprecated, or backend-only models (such as `Tab_flash_lite_preview` and `Chat_20706`) alongside the primary conversational models. 

Previously, the extension blindly passed through all usage buckets returned by the Google Cloud Quota API without any filtering. This made it difficult for users to quickly check their actual quotas on the fly. 

This update introduces an explicit filtering layer:
- **API Responses:** Updates the `parseBuckets` parser in `src/services/quotaApi.ts` to drop any models not explicitly declared in `MODEL_DISPLAY_NAMES`.
- **Local Data:** Updates the `buildAccountCards` logic in `src/managers/accountCardBuilder.ts` to filter the IDE's local cascade model configs against the same `MODEL_DISPLAY_NAMES` list.

## Changes Made
- Modified `src/services/quotaApi.ts` to drop model IDs absent from `MODEL_DISPLAY_NAMES`.
- Modified `src/managers/accountCardBuilder.ts` to enforce filtering of `clientModelConfigs` using the canonical display names.

## Testing
- Verified that compiling and packaging the extension locally succeeds.
- Verified that the "Accounts" tab now strictly reflects only the models available in the Antigravity IDE dropdown.

## Related Issues
- Restores previous functionality by decluttering the quota view.
